### PR TITLE
Print to stderr instead of stdout

### DIFF
--- a/src/NVMPI_frameBuf.cpp
+++ b/src/NVMPI_frameBuf.cpp
@@ -8,14 +8,14 @@ bool NVMPI_frameBuf::alloc(NvBufferCreateParams& input_params)
 	ret = NvBufSurf::NvAllocate(&input_params, 1, &dst_dma_fd);
 	if(ret<0)
 	{
-		std::cout << "Failed to allocate buffer" << std::endl;
+		std::cerr << "Failed to allocate buffer" << std::endl;
 		return false;
 	}
 	
 	ret = NvBufSurfaceFromFd(dst_dma_fd, (void**)(&dst_dma_surface));
 	if(ret<0)
 	{
-		std::cout << "Failed to get surface for buffer" << std::endl;
+		std::cerr << "Failed to get surface for buffer" << std::endl;
 		NvBufferDestroy(dst_dma_fd);
 		dst_dma_fd = -1;
 		return false;
@@ -24,7 +24,7 @@ bool NVMPI_frameBuf::alloc(NvBufferCreateParams& input_params)
 	ret = NvBufferCreateEx(&dst_dma_fd, &input_params);
 	if(ret<0)
 	{
-		std::cout << "Failed to allocate buffer" << std::endl;
+		std::cerr << "Failed to allocate buffer" << std::endl;
 		return false;
 	}
 #endif
@@ -40,7 +40,7 @@ bool NVMPI_frameBuf::destroy()
 		ret = NvBufferDestroy(dst_dma_fd);
 		if(ret<0)
 		{
-			std::cout << "Failed to Destroy NvBuffer" << std::endl;
+			std::cerr << "Failed to Destroy NvBuffer" << std::endl;
 			return false;
 		}
 		dst_dma_fd = -1;

--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -17,7 +17,7 @@
 #define TEST_ERROR(condition, message, errorCode)    \
 	if (condition)                               \
 {                                                    \
-	std::cout<< message;			     \
+	std::cerr<< message;			     \
 }
 
 using namespace std;
@@ -629,7 +629,7 @@ int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet)
 	ret = ctx->dec->output_plane.qBuffer(v4l2_buf, NULL);
 	if (ret < 0)
 	{
-		std::cout << "Error Qing buffer at output plane" << std::endl;
+		std::cerr << "Error Qing buffer at output plane" << std::endl;
 		ctx->index--;
 		return false;
 	}
@@ -637,7 +637,7 @@ int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet)
 	if (v4l2_buf.m.planes[0].bytesused == 0)
 	{
 		ctx->eos=true;
-		std::cout << "Input file read complete" << std::endl;
+		std::cerr << "Input file read complete" << std::endl;
 	}
 
 	return 0;

--- a/src/nvmpi_dec.cpp
+++ b/src/nvmpi_dec.cpp
@@ -585,6 +585,7 @@ nvmpictx* nvmpi_create_decoder(nvCodingType codingType, nvPixFormat pixFormat, n
 		ctx->dmaBufferFileDescriptor[index]=0;
 	ctx->numberCaptureBuffers=0;
 	ctx->dec_capture_loop = std::thread(dec_capture_loop_fcn,ctx);
+	pthread_setname_np(ctx->dec_capture_loop.native_handle(), "dec_capture");
 
 	return ctx;
 }

--- a/src/nvmpi_enc.cpp
+++ b/src/nvmpi_enc.cpp
@@ -13,7 +13,7 @@
 #define TEST_ERROR(condition, message, errorCode)    \
 	if (condition)                               \
 {                                                    \
-	std::cout<< message;                         \
+	std::cerr<< message;                         \
 }
 
 using namespace std;


### PR DESCRIPTION
ffmpeg commonly pipes video output to downstream processes via stdout, and thus prints all user messages to stderr. Ensure nvmpi messages go to stderr as well.