### PR TITLE
When NvUtils API is present, do not add nvbuf_utils lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,12 +45,15 @@ set(NVMPI_SRC
     ${JETSON_MULTIMEDIA_API_SRC_DIR}/NvVideoEncoder.cpp)
 
 # Use plain library names to allow stubbing
-set(NVMPI_DEP_LIBS ${CMAKE_THREAD_LIBS_INIT} nvv4l2 nvjpeg)
+set(NVMPI_DEP_LIBS ${CMAKE_THREAD_LIBS_INIT} nvv4l2 nvbuf_utils nvjpeg)
 
-add_definitions(-DWITH_NVUTILS)
-set(NVMPI_SRC ${NVMPI_SRC}
-	/usr/src/jetson_multimedia_api/samples/common/classes/NvBufSurface.cpp)
-set(NVMPI_DEP_LIBS ${NVMPI_DEP_LIBS} nvbufsurface nvbufsurftransform)
+#if NvUtils API is present prefer it to nvbuf_utils
+if(EXISTS "/usr/src/jetson_multimedia_api/include/nvbufsurface.h")
+	add_definitions(-DWITH_NVUTILS)
+	set(NVMPI_SRC ${NVMPI_SRC}
+		/usr/src/jetson_multimedia_api/samples/common/classes/NvBufSurface.cpp)
+  set(NVMPI_DEP_LIBS ${CMAKE_THREAD_LIBS_INIT} nvv4l2 nvjpeg nvbufsurface nvbufsurftransform)
+endif()
 
 add_library(nvmpi SHARED ${NVMPI_SRC})
 add_library(nvmpi_static STATIC ${NVMPI_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,12 @@ set(NVMPI_SRC
     ${JETSON_MULTIMEDIA_API_SRC_DIR}/NvVideoEncoder.cpp)
 
 # Use plain library names to allow stubbing
-set(NVMPI_DEP_LIBS ${CMAKE_THREAD_LIBS_INIT} nvv4l2 nvbuf_utils nvjpeg)
+set(NVMPI_DEP_LIBS ${CMAKE_THREAD_LIBS_INIT} nvv4l2 nvjpeg)
 
-#if NvUtils API is present prefer it to nvbuf_utils 
-if(EXISTS "/usr/src/jetson_multimedia_api/include/nvbufsurface.h")
-	add_definitions(-DWITH_NVUTILS)
-	set(NVMPI_SRC ${NVMPI_SRC}
-		/usr/src/jetson_multimedia_api/samples/common/classes/NvBufSurface.cpp)
-	set(NVMPI_DEP_LIBS ${NVMPI_DEP_LIBS} nvbufsurface nvbufsurftransform)
-endif()
+add_definitions(-DWITH_NVUTILS)
+set(NVMPI_SRC ${NVMPI_SRC}
+	/usr/src/jetson_multimedia_api/samples/common/classes/NvBufSurface.cpp)
+set(NVMPI_DEP_LIBS ${NVMPI_DEP_LIBS} nvbufsurface nvbufsurftransform)
 
 add_library(nvmpi SHARED ${NVMPI_SRC})
 add_library(nvmpi_static STATIC ${NVMPI_SRC})


### PR DESCRIPTION
Since Jetpack 5.1.2, `nvbuf_utils` is no longer present, and building with it included results in Frigate being unable to start up.

But, if the NvUtils API is present, you should not need the `nvbuf_utils` library anyways, so we can simply leave it out if cmake detects that it can use the NvUtils API.